### PR TITLE
Add DB seed scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ pnpm dev
 open http://localhost:5173
 ```
 
+### Seed Data
+
+If you want a seed data to play around with, or just an easily restorable state, you can run the following command:
+
+```bash
+pnpm supabase:seed
+```
+
+This will create 10 users with email logins as well as 10 games with a random amount of players and scores. Five games with a future end date and 5 games with a past end date. The seed data can be found in `supabase/seed.sql` which is run first with `supabase db reset` and then participation data is added with a javascript, to control the random data and tune it more easily.
+
 ### Troubleshooting
 
 If you run into issues with foreign key constraints on profile_id, you can try going to the profile page of a logged in user and hitting save first, then try creating a game again.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
 		"test:unit": "vitest",
 		"changeset:version": "changeset version && pnpm generate:version && git add --all",
 		"changeset:release": "changeset publish",
-		"generate:version": "node scripts/generate-version.js"
+		"generate:version": "node scripts/generate-version.js",
+		"supabase:seed": "supabase db reset && node --env-file=.env ./supabase/seed-participations.js"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.28.1",

--- a/supabase/seed-participations.js
+++ b/supabase/seed-participations.js
@@ -1,0 +1,99 @@
+import { createClient } from '@supabase/supabase-js';
+
+console.log('⚙️ Seeding participations...');
+
+const supabase = createClient(
+	process.env.PUBLIC_SUPABASE_URL,
+	process.env.PUBLIC_SUPABASE_ANON_KEY
+);
+
+const createSetOfScores = (length) => {
+	const scores = [];
+	for (let i = 0; i < length; i++) {
+		scores.push(Math.floor(Math.random() * 99) + 1);
+	}
+	return scores;
+};
+
+const addParticipation = async (gameId, userId, nickname, scores, nickname_image_url, endTime) => {
+	const referenceDate =
+		new Date(endTime).getTime() > new Date().getTime() ? new Date() : new Date(endTime);
+	const created_at = new Date(new Date(referenceDate).setUTCHours(-24));
+	const updated_at = new Date(new Date(referenceDate).setUTCHours(-2));
+
+	const participationData = {
+		nickname,
+		score: [...scores],
+		total_score: scores.reduce((acc, score) => acc + score, 0),
+		profile_id: userId,
+		game_id: gameId,
+		nickname_image_url,
+		created_at,
+		updated_at
+	};
+
+	const { error } = await supabase
+		.from('participation')
+		.insert(participationData)
+		.select()
+		.single();
+
+	if (error) {
+		console.error(error);
+	}
+};
+
+const { data: games, error: gamesError } = await supabase
+	.from('games')
+	.select('id, creator, code, end_at, name');
+if (gamesError) {
+	console.error(gamesError);
+}
+
+const { data: users, error: usersError } = await supabase
+	.from('profiles')
+	.select('id, username, avatar_url');
+
+if (usersError) {
+	console.error(gamesError);
+}
+
+for (const game of games) {
+	// Add participation for the creator
+	const creator = users.find((user) => user.id === game.creator);
+	const scoresPerPlayer = Math.floor(Math.random() * 5) + 1;
+	const scores = createSetOfScores(scoresPerPlayer);
+	addParticipation(game.id, creator.id, creator.username, scores, creator.avatar_url, game.end_at);
+
+	// Add participation for other players
+	const otherPlayers = users.filter((user) => user.id !== creator.id);
+	const numberOfOtherPlayers = Math.floor(Math.random() * otherPlayers.length);
+
+	// unique list of other players selected randomly
+	const generateListOfRandomPlayers = (players, count) => {
+		const selectedPlayers = new Set();
+		while (selectedPlayers.size < count) {
+			const randomPlayer = players[Math.floor(Math.random() * players.length)];
+			selectedPlayers.add(randomPlayer);
+		}
+		return selectedPlayers;
+	};
+	const selectedPlayers = generateListOfRandomPlayers(otherPlayers, numberOfOtherPlayers);
+
+	// Add participation for all other players
+	for (const player of selectedPlayers) {
+		const scores = createSetOfScores(scoresPerPlayer);
+		addParticipation(game.id, player.id, player.username, scores, player.avatar_url, game.end_at);
+	}
+
+	console.log(
+		`✔︎ Game ${game.name}: ${
+			numberOfOtherPlayers + 1
+		} players, ${scoresPerPlayer} scores per player`
+	);
+}
+
+console.log(`Database seeded with ${games.length} games and ${users.length} users.`);
+console.log(
+	`login with the following credentials: user{1-${users.length}}@example.com / password123`
+);

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,72 @@
+-- create test users
+INSERT INTO
+    auth.users (
+        instance_id,
+        id,
+        aud,
+        role,
+        email,
+        encrypted_password,
+        email_confirmed_at,
+        recovery_sent_at,
+        last_sign_in_at,
+        raw_app_meta_data,
+        raw_user_meta_data,
+        created_at,
+        updated_at,
+        confirmation_token,
+        email_change,
+        email_change_token_new,
+        recovery_token
+    ) (
+        select
+            '00000000-0000-0000-0000-000000000000',
+            uuid_generate_v4 (),
+            'authenticated',
+            'authenticated',
+            'user' || (ROW_NUMBER() OVER ()) || '@example.com',
+            crypt ('password123', gen_salt ('bf')),
+            current_timestamp,
+            current_timestamp,
+            current_timestamp,
+            '{"provider":"email","providers":["email"]}',
+            '{}',
+            current_timestamp,
+            current_timestamp,
+            '',
+            '',
+            '',
+            ''
+        FROM
+            generate_series(1, 10)
+    );
+
+-- test user email identities
+INSERT INTO
+    auth.identities (
+        provider_id,
+        user_id,
+        identity_data,
+        provider,
+        last_sign_in_at,
+        created_at,
+        updated_at
+    ) (
+        select
+            uuid_generate_v4 (),
+            id,
+            format('{"sub":"%s","email":"%s"}', id::text, email)::jsonb,
+            'email',
+            current_timestamp,
+            current_timestamp,
+            current_timestamp
+        from
+            auth.users
+    );
+
+-- Add profiles for test users
+UPDATE public.profiles
+SET username = 'user ' || SUBSTRING(id::text FROM 1 FOR 8),
+    avatar_url = 'https://api.dicebear.com/8.x/pixel-art/svg?seed=' || SUBSTRING(id::text FROM 1 FOR 8),
+    updated_at = current_timestamp
+WHERE id IN (SELECT id FROM auth.users);

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -70,3 +70,36 @@ SET username = 'user ' || SUBSTRING(id::text FROM 1 FOR 8),
     avatar_url = 'https://api.dicebear.com/8.x/pixel-art/svg?seed=' || SUBSTRING(id::text FROM 1 FOR 8),
     updated_at = current_timestamp
 WHERE id IN (SELECT id FROM auth.users);
+
+-- Add games
+INSERT INTO
+    public.games (
+        created_at,
+        name,
+        code,
+        is_active,
+        creator,
+        end_at,
+        updated_at,
+        cooldown_hours,
+        ai_enabled
+    ) (
+        select
+            current_timestamp,
+            'Game ' || (ROW_NUMBER() OVER ()),
+            'game-' || SUBSTRING((uuid_generate_v4 ())::text FROM 1 FOR 8) || '-' || SUBSTRING((uuid_generate_v4 ())::text FROM 1 FOR 8),
+            CASE 
+                WHEN (ROW_NUMBER() OVER ()) <= 5 THEN true
+                ELSE false
+            END,
+            id,
+            CASE 
+                WHEN (ROW_NUMBER() OVER ()) <= 5 THEN current_timestamp + interval '5 days'
+                ELSE current_timestamp - interval '1 day'
+            END,
+            current_timestamp,
+            (ROW_NUMBER() OVER ()) % 2,
+            false
+        from
+            auth.users
+    );


### PR DESCRIPTION
Adds a script to easily seed the db tables with users, games and participation. Makes it easy to have a restorable state with test data locally.

```bash
pnpm supabase:seed
```