### PR TITLE
Fix/validate score cooldown

### DIFF
--- a/.changeset/ninety-apes-mix.md
+++ b/.changeset/ninety-apes-mix.md
@@ -1,0 +1,5 @@
+---
+'authenticlash': minor
+---
+
+use daily cooldowns instead of by hour

--- a/src/lib/supabase/games.ts
+++ b/src/lib/supabase/games.ts
@@ -250,6 +250,28 @@ export const getGameBackgroundPrompt = async (
 	return successResponse;
 };
 
+export const getGameCooldownHoursById = async (
+	gameId: string
+): Promise<SupabaseResponse<number>> => {
+	const { data, error } = await supabaseServerClient
+		.from('games')
+		.select('cooldown_hours')
+		.eq('id', gameId)
+		.single();
+
+	if (error !== null) {
+		const r: SupabaseResponse<number> = { type: 'error', data: null, error };
+		return r;
+	}
+
+	const successResponse: SupabaseResponse<number> = {
+		type: 'success',
+		data: data.cooldown_hours as number,
+		error: null
+	};
+	return successResponse;
+};
+
 const mapToGame = (data: any): Game => {
 	return {
 		id: data.id as number,

--- a/src/lib/supabase/participation.ts
+++ b/src/lib/supabase/participation.ts
@@ -75,7 +75,7 @@ export const updateParticipationScore = async (
 	const existingScore = existingParticipation.score || [];
 	const newScore = [...existingScore, score];
 	const newTotalScore = newScore.reduce((acc, curr) => acc + curr, 0);
-	const { data, error } = await supabase
+	const { data, error } = await supabaseServerClient
 		.from('participation')
 		.update({
 			score: newScore,
@@ -107,7 +107,7 @@ export const updateParticipationNicknameImage = async (
 	nicknameImageUrl: string,
 	participationId: string
 ): Promise<SupabaseResponse<Participation>> => {
-	const { data, error } = await supabase
+	const { data, error } = await supabaseServerClient
 		.from('participation')
 		.update({ nickname_image_url: nicknameImageUrl })
 		.eq('id', participationId)
@@ -146,7 +146,7 @@ export const addParticipation = async (
 		created_at: new Date(),
 		updated_at: new Date()
 	};
-	const { data, error } = await supabase
+	const { data, error } = await supabaseServerClient
 		.from('participation')
 		.insert(participationData)
 		.select()

--- a/src/lib/utils/dateUtils.ts
+++ b/src/lib/utils/dateUtils.ts
@@ -57,3 +57,29 @@ export function timeUntilCooldownEnds(lastUpdatedISO: string | null, cooldownHou
 
 	return Math.max(0, remainingTimeMillis);
 }
+
+// Returns true if both dates are on the same UTC calendar day
+export function isSameUtcDay(a: Date, b: Date): boolean {
+	return (
+		a.getUTCFullYear() === b.getUTCFullYear() &&
+		a.getUTCMonth() === b.getUTCMonth() &&
+		a.getUTCDate() === b.getUTCDate()
+	);
+}
+
+// Milliseconds until the next UTC midnight from the given date (default: now)
+export function msUntilNextUtcMidnight(from: Date = new Date()): number {
+	const next = new Date(
+		Date.UTC(from.getUTCFullYear(), from.getUTCMonth(), from.getUTCDate() + 1, 0, 0, 0, 0)
+	);
+	return Math.max(0, next.getTime() - from.getTime());
+}
+
+// Daily cooldown helper: 0 if last update wasn't today (UTC) or null; otherwise ms until next UTC midnight
+export function timeUntilDailyCooldownEnds(lastUpdatedISO: string | null): number {
+	if (!lastUpdatedISO) return 0;
+	const lastUpdated = new Date(lastUpdatedISO);
+	const now = new Date();
+	if (!isSameUtcDay(lastUpdated, now)) return 0;
+	return msUntilNextUtcMidnight(now);
+}

--- a/src/routes/games/[code]/+page.svelte
+++ b/src/routes/games/[code]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import InlineMessage from '$lib/components/InlineMessage.svelte';
 	import { page } from '$app/state';
-	import { formatTimeDelta, timeUntilCooldownEnds } from '$lib/utils/dateUtils.js';
+	import { formatTimeDelta, timeUntilDailyCooldownEnds } from '$lib/utils/dateUtils.js';
 	import GameHighScore from './GameHighScore.svelte';
 	import {
 		Clock,
@@ -40,9 +40,7 @@
 	);
 	const players = $derived(data.players);
 
-	let cooldownRemaining = $state(
-		timeUntilCooldownEnds(data.currentPlayer?.updatedAt, data.cooldownHours)
-	);
+	let cooldownRemaining = $state(timeUntilDailyCooldownEnds(data.currentPlayer?.updatedAt));
 
 	const millisecondsToEnd = new Date(data.endsAt).getTime();
 	let millisecondsNow = new Date().getTime();
@@ -92,7 +90,7 @@
 					duration: 15000
 				});
 				if (result.data) {
-					cooldownRemaining = timeUntilCooldownEnds(new Date().toISOString(), data.cooldownHours);
+					cooldownRemaining = timeUntilDailyCooldownEnds(new Date().toISOString());
 				}
 			}
 			if (result.type === 'failure') {

--- a/src/routes/games/create/+page.server.ts
+++ b/src/routes/games/create/+page.server.ts
@@ -14,7 +14,6 @@ export const actions = {
 	create: async ({ request, locals: { supabase, safeGetSession } }) => {
 		const formData = await request.formData();
 		const name = formData.get('game-name');
-		const cooldown = formData.get('2fa-cooldown');
 		const commentatorPersonality = formData.get('commentator-personality');
 		const backgroundPrompt = formData.get('background-prompt');
 		const endDate = formData.get('end-date');
@@ -28,7 +27,6 @@ export const actions = {
 				name,
 				endDate,
 				endTime,
-				cooldown,
 				message: 'Could not find an active session, please try logging in again. 🙏'
 			});
 		}
@@ -40,7 +38,7 @@ export const actions = {
 			code: generatedId,
 			creator: session.user.id,
 			is_active: true,
-			cooldown_hours: cooldown,
+			cooldown_hours: '24', // trying out a daily cooldown instead of using this field
 			created_at: new Date(),
 			updated_at: new Date(),
 			commentator_personality: commentatorPersonality,
@@ -55,7 +53,6 @@ export const actions = {
 				name,
 				endDate,
 				endTime,
-				cooldown,
 				message: 'Error creating game. Please try again. 🙏'
 			});
 		}

--- a/src/routes/games/create/+page.svelte
+++ b/src/routes/games/create/+page.svelte
@@ -35,7 +35,6 @@
 	let backgroundPrompt = $state<string>('');
 
 	const endTime: string = form?.endTime?.toString() ?? '12:00';
-	const cooldown: string = form?.cooldown?.toString() ?? '16';
 	let isLoading = $state(false);
 
 	const handleSubmit: SubmitFunction = () => {
@@ -88,30 +87,6 @@
 					</div>
 				</div>
 
-				<div class="col-span-6">
-					<label for="2fa-cooldown" class="text-foreground block text-sm leading-6 font-medium"
-						>2FA Entry Cooldown (0-24h)</label
-					>
-					<div class="text-muted-foreground text-xs">
-						Limit how often players can enter 2FA values
-					</div>
-					<div class="mt-2 max-w-12">
-						<div
-							class="focus-within:ring-ring ring-foreground/10 hover:bg-muted flex rounded-md bg-white/5 shadow-2xs ring-1 ring-inset focus-within:ring-2 focus-within:ring-inset"
-						>
-							<input
-								type="number"
-								name="2fa-cooldown"
-								id="2fa-cooldown"
-								value={cooldown}
-								required
-								min="0"
-								max="24"
-								class="text-foreground flex-1 border-0 bg-transparent py-1.5 pl-2 focus:outline-0 sm:text-sm sm:leading-6"
-							/>
-						</div>
-					</div>
-				</div>
 				<div class="col-span-4 sm:col-span-3">
 					<label for="end-date" class="text-foreground block text-sm leading-6 font-medium"
 						>End date</label

--- a/supabase/migrations/20250830093000_enable_rls_participation.sql
+++ b/supabase/migrations/20250830093000_enable_rls_participation.sql
@@ -1,0 +1,21 @@
+-- Enable Row Level Security on participation and add policies
+-- - Public (anon, authenticated) may read all rows
+-- - service_role may perform all operations
+
+alter table if exists public.participation enable row level security;
+
+-- Allow public roles to read participation rows
+create policy "Public can read participation"
+on public.participation
+for select
+to anon, authenticated
+using (true);
+
+-- Ensure service_role can do all operations
+create policy "Service role full access to participation"
+on public.participation
+for all
+to service_role
+using (true)
+with check (true);
+


### PR DESCRIPTION
Summary

- Enforce cooldown on the server to prevent extra 2FA entries by tampering with the UI or calling the endpoint directly.
- Switch cooldown semantics to once per UTC day (one submission per calendar day).
- Enable RLS on participation with public read and service_role full access.
- Update write paths to use service role so they keep working under RLS.
- Improve cooldown messaging to human-friendly durations.