### PR TITLE
Feat/add game end image

### DIFF
--- a/.changeset/nervous-buses-talk.md
+++ b/.changeset/nervous-buses-talk.md
@@ -1,0 +1,5 @@
+---
+'authenticlash': minor
+---
+
+Add engame image feature

--- a/src/lib/ai/image-generator.ts
+++ b/src/lib/ai/image-generator.ts
@@ -34,6 +34,37 @@ export async function generateImage(
 	}
 }
 
+export async function generateEndgameImage(
+	winnerName: string,
+	competitors: string[],
+	backgroundPrompt?: string
+): Promise<string | undefined> {
+	try {
+		const prompt = createEndgameImagePrompt(winnerName, competitors, backgroundPrompt);
+		console.debug('Generating endgame image with prompt: ', prompt);
+		const image = await openaiClient.images.generate({
+			quality: 'standard',
+			model: 'dall-e-3',
+			size: '1024x1024',
+			n: 1,
+			response_format: 'url',
+			prompt
+		});
+
+		if (!image.data) {
+			console.error('No image data returned from OpenAI for endgame image');
+			return undefined;
+		}
+
+		console.debug('Endgame revised image prompt: ', image.data[0]?.revised_prompt);
+		console.debug('Endgame image URL: ', image.data[0]?.url);
+		return image.data[0].url;
+	} catch (error) {
+		console.error('Error generating endgame image: ', error);
+		return undefined;
+	}
+}
+
 function createImagePrompt(username: string, backgroundPrompt?: string) {
 	const nameStrippedOfParentheses = username.replace(/\(.*\)/, '').trim();
 	const [descriptor, creature = nameStrippedOfParentheses] = nameStrippedOfParentheses.split(' ');
@@ -42,4 +73,24 @@ function createImagePrompt(username: string, backgroundPrompt?: string) {
 	const backdrop = backgroundPrompt || backdrops[Math.floor(Math.random() * backdrops.length)];
 
 	return `Create an image of a ${descriptor} ${creature}, with the background theme of "${backdrop}".`;
+}
+
+function createEndgameImagePrompt(
+	winnerName: string,
+	competitors: string[],
+	backgroundPrompt?: string
+) {
+	const clean = (name: string) => name.replace(/\(.*\)/, '').trim();
+
+	const winner = clean(winnerName);
+	const others = competitors.map(clean).filter((n) => n && n !== winner);
+
+	// Reframe opponents as emblems/banners (non-living)
+	const opponentNouns = others.length
+		? `, standing triumphant as champion before ${others.join(', ')}`
+		: ', standing triumphant as champion';
+
+	const backdrop = backgroundPrompt || backdrops[Math.floor(Math.random() * backdrops.length)];
+
+	return `Create an epic, high-detail, cinematic image of ${winner}${opponentNouns}. Background theme: "${backdrop}".`;
 }

--- a/src/lib/supabase/games.ts
+++ b/src/lib/supabase/games.ts
@@ -9,6 +9,7 @@ export type Game = {
 	cooldown_hours: number;
 	ai_enabled: boolean;
 	background_prompt?: string;
+	endgame_image_url?: string;
 	creator: string;
 	is_active: boolean;
 	participation: Participation[];
@@ -20,7 +21,7 @@ export type EndedActiveGame = {
 };
 
 const GAME_SELECT_QUERY =
-	'id, code, creator, end_at, is_active, name, cooldown_hours, ai_enabled, background_prompt, participation ( id, score, total_score, profile_id, updated_at, nickname_image_url, nickname, ability_used, class_id )';
+	'id, code, creator, end_at, is_active, name, cooldown_hours, ai_enabled, background_prompt, endgame_image_url, participation ( id, score, total_score, profile_id, updated_at, nickname_image_url, nickname, ability_used, class_id )';
 
 export const getGame = async (code: string): Promise<SupabaseResponse<Game | null>> => {
 	const { data: game, error } = await supabaseServerClient
@@ -250,6 +251,23 @@ export const getGameBackgroundPrompt = async (
 	return successResponse;
 };
 
+export const setGameEndgameImageUrl = async (
+	gameId: string,
+	url: string
+): Promise<SupabaseResponse<boolean>> => {
+	const { error } = await supabaseServerClient
+		.from('games')
+		.update({ endgame_image_url: url })
+		.eq('id', gameId);
+
+	if (error !== null) {
+		const r: SupabaseResponse<boolean> = { type: 'error', data: null, error };
+		return r;
+	}
+
+	return { type: 'success', data: true, error: null };
+};
+
 export const getGameCooldownHoursById = async (
 	gameId: string
 ): Promise<SupabaseResponse<number>> => {
@@ -281,6 +299,7 @@ const mapToGame = (data: any): Game => {
 		name: data.name as string,
 		cooldown_hours: data.cooldown_hours as number,
 		background_prompt: data.background_prompt as string | undefined,
+		endgame_image_url: data.endgame_image_url as string | undefined,
 		creator: data.creator as string,
 		is_active: data.is_active as boolean,
 		participation: data.participation.map(mapToParticipation)

--- a/src/lib/supabase/storage.ts
+++ b/src/lib/supabase/storage.ts
@@ -1,7 +1,8 @@
-import { supabase } from './supabaseClient';
+import { supabaseServerClient } from './supabaseClient';
 import sharp from 'sharp';
 
 export const PARTICIPANT_AVATARS_BUCKET = 'participant-avatars';
+export const GAME_IMAGES_BUCKET = 'game-images';
 
 export const uploadParticipantImage = async (
 	imageUrl: string,
@@ -23,13 +24,13 @@ export const uploadParticipantImage = async (
 	const full = await sharp(originalImage).webp({ quality: 90 }).toBuffer();
 
 	// upload to supabase storage
-	const { data: thumbnailData, error: thumbnailError } = await supabase.storage
+	const { data: thumbnailData, error: thumbnailError } = await supabaseServerClient.storage
 		.from(PARTICIPANT_AVATARS_BUCKET)
 		.upload(`${userId}/${participationId}-128.webp`, thumbnail, { contentType: 'image/webp' });
-	const { data: mediumData, error: mediumError } = await supabase.storage
+	const { data: mediumData, error: mediumError } = await supabaseServerClient.storage
 		.from(PARTICIPANT_AVATARS_BUCKET)
 		.upload(`${userId}/${participationId}-512.webp`, medium, { contentType: 'image/webp' });
-	const { data: fullData, error: fullError } = await supabase.storage
+	const { data: fullData, error: fullError } = await supabaseServerClient.storage
 		.from(PARTICIPANT_AVATARS_BUCKET)
 		.upload(`${userId}/${participationId}.webp`, full, { contentType: 'image/webp' });
 
@@ -52,4 +53,52 @@ export const uploadParticipantImage = async (
 		},
 		error: null
 	};
+};
+
+export const uploadGameImage = async (imageUrl: string, gameId: string | number) => {
+	const response = await fetch(imageUrl);
+	const originalImage = await response.arrayBuffer();
+
+	const thumbnail = await sharp(originalImage)
+		.resize({ width: 128, height: 128 })
+		.webp({ quality: 90 })
+		.toBuffer();
+	const medium = await sharp(originalImage)
+		.resize({ width: 512, height: 512 })
+		.webp({ quality: 90 })
+		.toBuffer();
+	const full = await sharp(originalImage).webp({ quality: 90 }).toBuffer();
+
+	// Store in the bucket root; include game id in the filename
+	const baseName = `endgame-${gameId}`;
+
+	const { data: thumbnailData, error: thumbnailError } = await supabaseServerClient.storage
+		.from(GAME_IMAGES_BUCKET)
+		.upload(`${baseName}-128.webp`, thumbnail, { contentType: 'image/webp', upsert: true });
+	const { data: mediumData, error: mediumError } = await supabaseServerClient.storage
+		.from(GAME_IMAGES_BUCKET)
+		.upload(`${baseName}-512.webp`, medium, { contentType: 'image/webp', upsert: true });
+	const { data: fullData, error: fullError } = await supabaseServerClient.storage
+		.from(GAME_IMAGES_BUCKET)
+		.upload(`${baseName}.webp`, full, { contentType: 'image/webp', upsert: true });
+
+	if (thumbnailError || mediumError || fullError) {
+		console.error(
+			'Error uploading game images:',
+			thumbnailError?.message,
+			mediumError?.message,
+			fullError?.message
+		);
+		return { type: 'error', data: null, fullError } as const;
+	}
+
+	return {
+		type: 'success',
+		data: {
+			thumbnailPath: thumbnailData.path,
+			mediumPath: mediumData.path,
+			fullPath: fullData.path
+		},
+		error: null
+	} as const;
 };

--- a/src/routes/games/[code]/+page.svelte
+++ b/src/routes/games/[code]/+page.svelte
@@ -31,7 +31,7 @@
 	import type { Ability } from '$lib/supabase/classes';
 	import GamePageHeader from './GamePageHeader.svelte';
 	import { quintOut } from 'svelte/easing';
-	import { fly } from 'svelte/transition';
+	import { fly, fade } from 'svelte/transition';
 
 	const { data }: { data: PageData } = $props();
 	let isLoading = $state(false);
@@ -301,6 +301,8 @@
 							action="?/generateEndgameImage"
 							use:enhance={handleGenerateEndgameImage}
 							class="mt-4"
+							in:fade={{ duration: 150 }}
+							out:fade={{ duration: 150 }}
 						>
 							<input type="hidden" name="game-id" value={data.gameId} />
 							<Button
@@ -314,7 +316,11 @@
 						</form>
 					{/if}
 					{#if isGeneratingEndgame}
-						<div class="mt-6 w-full max-w-sm">
+						<div
+							class="mt-6 w-full max-w-sm"
+							in:fade={{ duration: 150, delay: 155 }}
+							out:fade={{ duration: 150 }}
+						>
 							<div
 								class="bg-foreground/10 aspect-square w-full animate-pulse rounded-lg dark:bg-zinc-700/50"
 							></div>
@@ -323,11 +329,11 @@
 							</p>
 						</div>
 					{:else if endgameImageUrl}
-						<div class="mt-6 w-full max-w-sm">
+						<div class="mt-6 w-full max-w-sm" in:fade={{ duration: 150, delay: 155 }}>
 							<a href={endgameImageUrl} target="_blank" rel="noreferrer">
 								<img
 									src={endgameImageUrl.replace('.webp', '-512.webp')}
-									alt="Endgame image"
+									alt="Endgame scene"
 									class="w-full rounded-lg shadow"
 								/>
 							</a>

--- a/supabase/migrations/20250831080000_add-endgame-image-url.sql
+++ b/supabase/migrations/20250831080000_add-endgame-image-url.sql
@@ -1,0 +1,4 @@
+-- Add endgame_image_url to games table to persist generated endgame images
+ALTER TABLE public.games
+ADD COLUMN IF NOT EXISTS endgame_image_url TEXT NULL;
+

--- a/supabase/migrations/20250831080500_allow-service-role-on-games.sql
+++ b/supabase/migrations/20250831080500_allow-service-role-on-games.sql
@@ -1,0 +1,10 @@
+-- Allow service_role to perform all operations on games
+-- Note: service_role typically bypasses RLS, but this policy makes it explicit.
+
+CREATE POLICY "Allow ALL on games to service_role"
+ON public.games
+FOR ALL
+TO service_role
+USING (true)
+WITH CHECK (true);
+


### PR DESCRIPTION
## PR: Endgame “Epic Image” Generation + Persistence

- Feature: Add “Generate epic image” on ended games (AI-enabled). Builds a cinematic poster
of the winner crushing competitors using the game’s background prompt.
- OpenAI: New generateEndgameImage uses DALL·E 3; prompt includes winner, competitors, and
background theme.
- Storage: Uploads 3 WEBP variants to game-images (root) with filenames:
    - endgame-<gameId>.webp, endgame-<gameId>-512.webp, endgame-<gameId>-128.webp (upsert
enabled).
- Persistence: Store the public URL in games.endgame_image_url so the image shows after
refresh.
- UX: Added loading skeleton and smooth fade transitions for button → skeleton → final
image.

Changes

- src/routes/games/[code]/+page.svelte: Button, skeleton, image render with fade
transitions and persisted state.
- src/routes/games/[code]/+page.server.ts:
    - New generateEndgameImage action (fetch players + prompt, generate, upload, persist
URL).
    - load returns endgameImageUrl.
- src/lib/ai/image-generator.ts: generateEndgameImage(...) and tailored prompt builder.
- src/lib/supabase/storage.ts: GAME_IMAGES_BUCKET, uploadGameImage(...) storing at bucket
root with gameId in filename.
- src/lib/supabase/games.ts:
    - Include endgame_image_url in select and mapping.
    - setGameEndgameImageUrl(gameId, url) to persist.
- Migrations:
    - 20250831080000_add-endgame-image-url.sql: add endgame_image_url column to games.
    - 20250831080500_allow-service-role-on-games.sql: allow service_role ALL operations
on games.