### PR TITLE
Feat/barbarian passive

### DIFF
--- a/.changeset/ten-turtles-type.md
+++ b/.changeset/ten-turtles-type.md
@@ -1,0 +1,5 @@
+---
+'authenticlash': minor
+---
+
+Add barbarian passive ability

--- a/src/routes/games/[code]/+page.svelte
+++ b/src/routes/games/[code]/+page.svelte
@@ -9,6 +9,7 @@
 		Crosshair,
 		Dices,
 		Flame,
+		Axe,
 		HandCoins,
 		HandHeart,
 		LucideLoader2,
@@ -198,6 +199,8 @@
 													<Dices class="m-auto size-8" />
 												{:else if ability.id === ABILITIES.JUDGMENT}
 													<Gavel class="m-auto size-8" />
+												{:else if ability.name === "Berserker's Reprisal"}
+													<Axe class="m-auto size-8" />
 												{/if}
 											</div>
 										</div>

--- a/supabase/migrations/20250831091500_add_barbarian_passive.sql
+++ b/supabase/migrations/20250831091500_add_barbarian_passive.sql
@@ -1,0 +1,7 @@
+-- Add Barbarian passive ability: Berserker's Reprisal
+-- (Passive) After each negative entry, gain a Rage stack (max 3).
+-- Positive entries are boosted: 1=+15%, 2=+20%, 3=+25%.
+INSERT INTO public.abilities (class_id, name, description)
+VALUES
+    (3, 'Berserker''s Reprisal', '(Passive) After each negative entry, gain a Rage stack (max 3). Positive entries are boosted: 1=+15%, 2=+20%, 3=+25%.');
+


### PR DESCRIPTION
# Summary

- Adds a simple, punchy Barbarian passive: Berserker’s Reprisal. Negative entries build up to 3 Rage stacks; subsequent positive entries get 15%/20%/25% boost. No consumption or cooldown.
- Refactors passive handling to a dedicated function per class with a switch for clarity and future additions.
- Surfaces the passive in the UI and DB with a clean Axe icon.