### PR TITLE
fix: switch commentator model to gpt-5-mini

### DIFF
--- a/.changeset/gpt-5-mini-commentator.md
+++ b/.changeset/gpt-5-mini-commentator.md
@@ -1,0 +1,4 @@
+---
+"authenticlash": patch
+---
+use gpt-5-mini for commentator

--- a/src/lib/ai/game-event-commentator.ts
+++ b/src/lib/ai/game-event-commentator.ts
@@ -2,7 +2,7 @@ import { OPENAI_API_KEY } from '$env/static/private';
 import OpenAI from 'openai';
 
 const openaiClient = new OpenAI({ apiKey: process.env.OPENAI_API_KEY || OPENAI_API_KEY });
-const COMMENTATOR_MODEL = 'gpt-5-nano';
+const COMMENTATOR_MODEL = 'gpt-5-mini';
 
 type CommentatorEventResponse =
 	| {


### PR DESCRIPTION
## Summary
- use gpt-5-mini for commentator events
- add changeset

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b540c01930832e9a1d3d8f4057f420