### PR TITLE
refactor: unify image upload helpers

### DIFF
--- a/.changeset/merge-image-uploaders.md
+++ b/.changeset/merge-image-uploaders.md
@@ -1,0 +1,5 @@
+---
+'authenticlash': patch
+---
+
+refactor: consolidate participant and game image upload helpers

--- a/.changeset/thirty-guests-greet.md
+++ b/.changeset/thirty-guests-greet.md
@@ -1,0 +1,5 @@
+---
+'authenticlash': patch
+---
+
+use gpt-image-1 for avatar generation

--- a/src/lib/ai/image-generator.ts
+++ b/src/lib/ai/image-generator.ts
@@ -10,26 +10,21 @@ export async function generateImage(
 ): Promise<string | undefined> {
 	try {
 		const prompt = createImagePrompt(username, backgroundPrompt);
-		console.debug('Generating image with prompt: ', prompt);
+		console.debug('Generating image with gpt-image-1, prompt: ', prompt);
 		const image = await openaiClient.images.generate({
-			quality: 'standard',
-			model: 'dall-e-3',
+			model: 'gpt-image-1',
 			size: '1024x1024',
-			n: 1,
-			response_format: 'url',
 			prompt
 		});
 
-		if (!image.data) {
-			console.error('No image data returned from OpenAI');
+		const b64 = image.data?.[0]?.b64_json;
+		if (!b64) {
+			console.error('No b64 image data returned from OpenAI');
 			return undefined;
 		}
-
-		console.debug('Revised image prompt: ', image.data[0]?.revised_prompt);
-		console.debug('Image URL: ', image.data[0]?.url);
-		return image.data[0].url;
+		return b64;
 	} catch (error) {
-		console.error('Error generating image: ', error);
+		console.error('Error generating image with gpt-image-1: ', error);
 		return undefined;
 	}
 }

--- a/src/lib/supabase/storage.ts
+++ b/src/lib/supabase/storage.ts
@@ -4,106 +4,16 @@ import sharp from 'sharp';
 export const PARTICIPANT_AVATARS_BUCKET = 'participant-avatars';
 export const GAME_IMAGES_BUCKET = 'game-images';
 
-export const uploadParticipantImage = async (
-	imageUrl: string,
-	userId: string,
-	participationId: string
+interface UploadImageOptions {
+	bucket: string;
+	baseName: string;
+	upsert?: boolean;
+}
+
+export const uploadImageFromBase64 = async (
+	base64: string,
+	{ bucket, baseName, upsert = true }: UploadImageOptions
 ) => {
-	// download image from url and resize+optimize before upload
-	const response = await fetch(imageUrl);
-	const originalImage = await response.arrayBuffer();
-
-	const thumbnail = await sharp(originalImage)
-		.resize({ width: 128, height: 128 })
-		.webp({ quality: 90 })
-		.toBuffer();
-	const medium = await sharp(originalImage)
-		.resize({ width: 512, height: 512 })
-		.webp({ quality: 90 })
-		.toBuffer();
-	const full = await sharp(originalImage).webp({ quality: 90 }).toBuffer();
-
-	// upload to supabase storage
-	const { data: thumbnailData, error: thumbnailError } = await supabaseServerClient.storage
-		.from(PARTICIPANT_AVATARS_BUCKET)
-		.upload(`${userId}/${participationId}-128.webp`, thumbnail, { contentType: 'image/webp' });
-	const { data: mediumData, error: mediumError } = await supabaseServerClient.storage
-		.from(PARTICIPANT_AVATARS_BUCKET)
-		.upload(`${userId}/${participationId}-512.webp`, medium, { contentType: 'image/webp' });
-	const { data: fullData, error: fullError } = await supabaseServerClient.storage
-		.from(PARTICIPANT_AVATARS_BUCKET)
-		.upload(`${userId}/${participationId}.webp`, full, { contentType: 'image/webp' });
-
-	if (thumbnailError || fullError || mediumError) {
-		console.error(
-			'Error uploading images:',
-			thumbnailError?.message,
-			mediumError?.message,
-			fullError?.message
-		);
-		return { type: 'error', data: null, fullError };
-	}
-
-	return {
-		type: 'success',
-		data: {
-			thumbnailPath: thumbnailData.path,
-			fullPath: fullData.path,
-			mediumPath: mediumData.path
-		},
-		error: null
-	};
-};
-
-export const uploadGameImage = async (imageUrl: string, gameId: string | number) => {
-	const response = await fetch(imageUrl);
-	const originalImage = await response.arrayBuffer();
-
-	const thumbnail = await sharp(originalImage)
-		.resize({ width: 128, height: 128 })
-		.webp({ quality: 90 })
-		.toBuffer();
-	const medium = await sharp(originalImage)
-		.resize({ width: 512, height: 512 })
-		.webp({ quality: 90 })
-		.toBuffer();
-	const full = await sharp(originalImage).webp({ quality: 90 }).toBuffer();
-
-	// Store in the bucket root; include game id in the filename
-	const baseName = `endgame-${gameId}`;
-
-	const { data: thumbnailData, error: thumbnailError } = await supabaseServerClient.storage
-		.from(GAME_IMAGES_BUCKET)
-		.upload(`${baseName}-128.webp`, thumbnail, { contentType: 'image/webp', upsert: true });
-	const { data: mediumData, error: mediumError } = await supabaseServerClient.storage
-		.from(GAME_IMAGES_BUCKET)
-		.upload(`${baseName}-512.webp`, medium, { contentType: 'image/webp', upsert: true });
-	const { data: fullData, error: fullError } = await supabaseServerClient.storage
-		.from(GAME_IMAGES_BUCKET)
-		.upload(`${baseName}.webp`, full, { contentType: 'image/webp', upsert: true });
-
-	if (thumbnailError || mediumError || fullError) {
-		console.error(
-			'Error uploading game images:',
-			thumbnailError?.message,
-			mediumError?.message,
-			fullError?.message
-		);
-		return { type: 'error', data: null, fullError } as const;
-	}
-
-	return {
-		type: 'success',
-		data: {
-			thumbnailPath: thumbnailData.path,
-			mediumPath: mediumData.path,
-			fullPath: fullData.path
-		},
-		error: null
-	} as const;
-};
-
-export const uploadGameImageFromBase64 = async (base64: string, gameId: string | number) => {
 	const originalImage = Buffer.from(base64, 'base64');
 
 	const thumbnail = await sharp(originalImage)
@@ -116,21 +26,21 @@ export const uploadGameImageFromBase64 = async (base64: string, gameId: string |
 		.toBuffer();
 	const full = await sharp(originalImage).webp({ quality: 90 }).toBuffer();
 
-	const baseName = `endgame-${gameId}`;
+	const uploadOpts = { contentType: 'image/webp', upsert } as const;
 
 	const { data: thumbnailData, error: thumbnailError } = await supabaseServerClient.storage
-		.from(GAME_IMAGES_BUCKET)
-		.upload(`${baseName}-128.webp`, thumbnail, { contentType: 'image/webp', upsert: true });
+		.from(bucket)
+		.upload(`${baseName}-128.webp`, thumbnail, uploadOpts);
 	const { data: mediumData, error: mediumError } = await supabaseServerClient.storage
-		.from(GAME_IMAGES_BUCKET)
-		.upload(`${baseName}-512.webp`, medium, { contentType: 'image/webp', upsert: true });
+		.from(bucket)
+		.upload(`${baseName}-512.webp`, medium, uploadOpts);
 	const { data: fullData, error: fullError } = await supabaseServerClient.storage
-		.from(GAME_IMAGES_BUCKET)
-		.upload(`${baseName}.webp`, full, { contentType: 'image/webp', upsert: true });
+		.from(bucket)
+		.upload(`${baseName}.webp`, full, uploadOpts);
 
 	if (thumbnailError || mediumError || fullError) {
 		console.error(
-			'Error uploading game images from base64:',
+			'Error uploading images:',
 			thumbnailError?.message,
 			mediumError?.message,
 			fullError?.message
@@ -148,3 +58,19 @@ export const uploadGameImageFromBase64 = async (base64: string, gameId: string |
 		error: null
 	} as const;
 };
+
+export const uploadParticipantImage = async (
+	base64: string,
+	userId: string,
+	participationId: string
+) =>
+	uploadImageFromBase64(base64, {
+		bucket: PARTICIPANT_AVATARS_BUCKET,
+		baseName: `${userId}/${participationId}`
+	});
+
+export const uploadGameImage = async (base64: string, gameId: string | number) =>
+	uploadImageFromBase64(base64, {
+		bucket: GAME_IMAGES_BUCKET,
+		baseName: `endgame-${gameId}`
+	});

--- a/src/routes/games/[code]/+page.server.ts
+++ b/src/routes/games/[code]/+page.server.ts
@@ -10,7 +10,7 @@ import {
 	PARTICIPANT_AVATARS_BUCKET,
 	uploadParticipantImage,
 	GAME_IMAGES_BUCKET,
-	uploadGameImageFromBase64
+	uploadGameImage
 } from '$lib/supabase/storage';
 import { checkForValueEntryBadge } from '$lib/badges/valueEntryBadges';
 import { checkForAbilityBadge } from '$lib/badges/abilityBadges';
@@ -167,15 +167,15 @@ export const actions = {
 
 		const backgroundPrompt =
 			backgroundPromptRes.type === 'success' ? backgroundPromptRes.data : undefined;
-		const imageUrl = await generateImage(nickname.toString(), backgroundPrompt || undefined);
-		if (!imageUrl) {
+		const b64 = await generateImage(nickname.toString(), backgroundPrompt || undefined);
+		if (!b64) {
 			return fail(500, {
 				message: 'Oh no, your image could not be generated. Please try again. 🙏'
 			});
 		}
 
 		const uploadRes = await uploadParticipantImage(
-			imageUrl,
+			b64,
 			session.user.id,
 			participationId.toString()
 		);
@@ -237,7 +237,7 @@ export const actions = {
 			return fail(500, { message: 'Could not generate endgame image. Please try again.' });
 		}
 
-		const uploadRes = await uploadGameImageFromBase64(b64, gameId.toString());
+		const uploadRes = await uploadGameImage(b64, gameId.toString());
 		if (uploadRes.type === 'error' || !uploadRes.data?.fullPath) {
 			return fail(500, { message: 'Could not upload endgame image. Please try again.' });
 		}


### PR DESCRIPTION
## Summary
- consolidate participant and game image uploads into shared helper
- update server routes to use unified upload functions
- document image upload refactor in changeset

## Testing
- ✅ `pnpm lint`
- ⚠️ `pnpm check` (missing PUBLIC_SUPABASE_URL)
- ⚠️ `pnpm build` (missing PUBLIC_SUPABASE_URL)


------
https://chatgpt.com/codex/tasks/task_e_68b5448fb1e4832e931490bcdec93c61