### PR TITLE
fix: remove duplicate ability id field

### DIFF
--- a/.changeset/many-dingos-sing.md
+++ b/.changeset/many-dingos-sing.md
@@ -1,0 +1,5 @@
+---
+'authenticlash': patch
+---
+
+remove redundant ability id

--- a/src/routes/games/[code]/+page.svelte
+++ b/src/routes/games/[code]/+page.svelte
@@ -145,7 +145,7 @@
 		{#if timeLeft > 0}
 			<form method="POST" action="?/updateScore" use:enhance={handleNewScore}>
 				<input type="hidden" name="game-id" id="game-id" value={data.gameId} />
-				<input type="hidden" name="ability-id" id="ability-id" value={abilityIdUsed} />
+				<input type="hidden" name="ability-id" id="ability-id" bind:value={abilityIdUsed} />
 
 				<div class="space-y-6">
 					<div class="space-y-2">
@@ -257,7 +257,6 @@
 								</div>
 							</div>
 						{/each}
-						<input type="hidden" name="ability-id" id="ability-id" bind:value={abilityIdUsed} />
 					{/if}
 					<div class="relative col-span-6 sm:col-span-3">
 						{#if cooldownRemaining <= 0}


### PR DESCRIPTION
## Summary
- remove redundant ability-id hidden input on game page and bind remaining field to abilityIdUsed

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b972563610832e84cd8f98691dd5df